### PR TITLE
Fixes #3 - 32 bit pointer conversion

### DIFF
--- a/Verify.xs
+++ b/Verify.xs
@@ -119,22 +119,22 @@ static SV *callback = (SV *) NULL;
 
 static int cb1(ok, ctx)
     int ok;
-    UV *ctx;
+    IV *ctx;
 {
     dSP;
     int count;
     int i;
 
     //printf("Callback pointer: %p\n", ctx);
-    //printf("Callback UL of pointer %lu\n", PTR2UV(ctx));
+    //printf("Callback INT of pointer %lu\n", (unsigned long) PTR2IV(ctx));
     ENTER;
     SAVETMPS;
 
     PUSHMARK(SP);
     EXTEND(SP, 2);
 
-    PUSHs(newSVuv(ok));                 // Pass ok as integer on the stack
-    PUSHs(newSVuv(PTR2UV(ctx)));        // Pass pointer address as integer
+    PUSHs(newSViv(ok));                 // Pass ok as integer on the stack
+    PUSHs(newSViv(PTR2IV(ctx)));        // Pass pointer address as integer
     PUTBACK;
 
     count = call_sv(callback, G_SCALAR);  // Call the verify_callback()
@@ -389,15 +389,15 @@ to the point address to be used
 =cut
 
 int ctx_error_code(ctx)
-    UV ctx;
+    IV ctx;
 
     PREINIT:
 
     CODE:
-        /* printf("ctx_error_code - UL holding pointer: %lu\n", ctx); */
-        /* printf("ctx_error_code - Pointer to ctx: %p\n", (void *) INT2PTR(UV , ctx)); */
+        /* printf("ctx_error_code - int holding pointer: %lu\n", (unsigned long) ctx); */
+        /* printf("ctx_error_code - Pointer to ctx: %p\n", (void *) INT2PTR(SV * , ctx)); */
 
-        RETVAL = X509_STORE_CTX_get_error((X509_STORE_CTX *) INT2PTR(UV, ctx));
+        RETVAL = X509_STORE_CTX_get_error((X509_STORE_CTX *) INT2PTR(SV *, ctx));
 
     OUTPUT:
 


### PR DESCRIPTION
Wondering if magic should be used here instead of point conversion to an int and back.

This has an issue with t/06-verify-expired-cert.t if the 2 printfs are uncommented in for pointer debugging at L128 and L397.

This will fix the issue on 32-bit Debian and possibly even work on Windows cpantesters