### PR TITLE
Respect PERL_LIBPATH if set

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -19,7 +19,9 @@ sub search_lib {
     }
     my $libbase = 'lib' . substr($lib, 2) . $Config{lib_ext};
     my $libbase_so = 'lib' . substr($lib, 2) . "." . $Config{so};
-    for my $path (split(' ', $Config{libpth})) {
+    my @paths = split(' ', $Config{libpth});
+    push @paths, $ENV{PERL_LIBPATH} if exists $ENV{PERL_LIBPATH};
+    for my $path (@paths) {
         if (-f $path . '/' . $libbase) {
             print "$path/$libbase\n";
             print "Found '$path/$libbase'.\n";


### PR DESCRIPTION
When building this on a system where libcrypto is in a path not known to Perl 'perl Makefile.PL' will fail with the following error

* libcrypto is not installed or not in the default lib path. Aborting

This allows that path to be overridden by setting the PERL_LIBPATH environment variable.